### PR TITLE
refactor: Clean up functions, refine behaviour

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,17 +1,16 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean install of Node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,11 +18,11 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: yarn install --force
-    - run: yarn build
-    - run: yarn test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --force
+      - run: yarn build
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It returns another function that you can then pass arguments to. Your generated 
 ```js
 // my-script.js
 
-const climp = require('climp').default;
+const {default: climp} = require('climp');
 
 // Import functions from your own code
 const {doSomething, doAnotherThing} = require('./my-code');
@@ -30,7 +30,7 @@ const cli = climp({
     'do-something': {
       func: doSomething,
       args: {
-        argName: {
+        'arg-name': {
           type: 'string',
         },
       },
@@ -41,13 +41,13 @@ const cli = climp({
   },
 });
 
-// ['node', 'my-script.js', 'do-something', '--argName', 'argValue']
+// ['node', 'my-script.js', 'do-something', '--arg-name', 'arg-value']
 const args = process.argv.slice(2);
 
-cli(args); // doSomething({argName: 'argValue'})
+cli(args); // doSomething({'arg-name': 'arg-value'})
 ```
 
-Note that it's up to you to trim off any unwanted arguments (i.e. `node`, `my-script.js`) before passing it to climp's CLI. You might get an error otherwise.
+_Note that it's up to you to trim off any unwanted arguments (i.e. `node`, `my-script.js`) before passing it to climp's CLI. You might get an error otherwise._
 
 Check out the tests (`tests/climp.test.ts`) for some more examples on usage.
 
@@ -64,18 +64,6 @@ interface Config {
   };
 }
 ```
-
-### `Commands`
-
-_TODO write docs_
-
-### `Args`
-
-_TODO write docs_
-
-### `PositionalArgs`
-
-_TODO write docs_
 
 ## Errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climp",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "description": "A tool for building Node CLIs",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/PosArgs.ts
+++ b/src/PosArgs.ts
@@ -4,6 +4,7 @@ import {ErrorMessage} from './constants';
 
 import type {PositionalArgsDescriptor, Type} from './types';
 
+// Stack-based parsing class for positional args
 export default class PosArgs {
   readonly minRequired: number;
   readIn: number;


### PR DESCRIPTION
- Cleaner implementations
- Better documentation/comments
- More intuitive parsing behaviour (command-specific named args should override global named args)